### PR TITLE
fix: Allow symfony/process 7x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "require": {
         "illuminate/support": "^10.10.0|^11.0",
         "illuminate/console": "^10.10.0|^11.0",
-        "symfony/process": "^6.4"
+        "symfony/process": "^6.4|^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",


### PR DESCRIPTION
This is needed for Laravel 11 support (because Laravel 11 requires symfony/process 7x)

Looks like the changes from v6 to v7 are minimal and unrelated: https://github.com/symfony/process/blob/7.1/CHANGELOG.md