### PR TITLE
feat: Made gpio state parsing more flexible

### DIFF
--- a/src/Shell/RaspiGpio.php
+++ b/src/Shell/RaspiGpio.php
@@ -42,20 +42,19 @@ class RaspiGpio implements Commandable
     {
         $matches = [];
 
-        preg_match(
-            '/GPIO\s(\d+):\slevel=(1|0)\sfsel=(\d)\sa?l?t?=?(\d)?\s?func=(\w+)/',
-            $state,
-            $matches
-        );
+        [$prefix, $options] = explode(':', $state);
 
-        [, $pin, $level, $fsel, $alt, $func] = $matches;
+        preg_match('/GPIO\s(\d+)/', $prefix, $matches);
+        [, $pin] = $matches;
+
+        $options = parse_ini_string(str_replace(' ', PHP_EOL, $options));
 
         return Pin::make(
             pinNumber: (int) $pin,
-            level: Level::from($level),
-            fsel: (int) $fsel,
-            func: $func,
-            alt: $alt ? (int) $alt : null,
+            level: Level::from($options['level'] ?? 0),
+            fsel: isset($options['fsel']) ? (int) $options['fsel'] : null,
+            func: $options['func'] ?? null,
+            alt: $options['alt'] ?? null,
         );
     }
 

--- a/tests/Shell/RaspiGpio/GetSinglePinTest.php
+++ b/tests/Shell/RaspiGpio/GetSinglePinTest.php
@@ -25,6 +25,21 @@ it('returns pin state for given pin', function () {
     assertSame('OUTPUT', $output->func);
 });
 
+it('returns pin state for given pin when fsel is not set', function () {
+    Process::fake([
+        'raspi-gpio get 13' => Process::result(
+            output: 'GPIO 13: level=0 func=INPUT',
+        ),
+    ]);
+
+    $input = Pinout::pin(13);
+
+    assertSame(13, $input->pinNumber);
+    assertSame(Level::LOW, $input->level);
+    assertSame(null, $input->fsel);
+    assertSame('INPUT', $input->func);
+});
+
 it('sets alt to null when not defined', function () {
     Process::fake([
         'raspi-gpio get 13' => Process::result(


### PR DESCRIPTION
Hey @danjohnson95. Thanks again for making this awesome library.

I'm working on a Raspberry Pi-based Halloween prop and this library is a key part of it (here's the entry point if you're curious: https://github.com/MiniCodeMonkey/halloween2024/blob/main/fortune-teller/app/Console/Commands/Server.php)

For some reason, my `raspi-gpio` tool doesn't seem to return an `fsel` (Raspbian Bookworm, Raspberry Pi 3).

I updated the state parsing code to be more flexible and just accept arbitrary values. I piggy-backed on the built-in `parse_ini_string(...)` since the key=value syntax basically is like an ini file.